### PR TITLE
feat: toggling hidden files/directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Key bindings:
 | e             | Edit selected file in $EDITOR                          |
 | gg            | Go to top most child in current directory              |
 | G             | Go to last child in current directory                  |
+| H             | Toggle hidden files in current directory               |
 | enter         | Collapse / expand selected directory                   |
 | esc           | Clear error message / stop current operation           |
 | ?             | Toggle help                                            |

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -267,6 +267,10 @@ func (s *State) processKeyDefault(msg tea.KeyMsg) tea.Cmd {
 		if child != nil && child.Info.Mode().IsRegular() {
 			return openEditor(child.Path)
 		}
+	case "H":
+		if err := s.Tree.ToggleHiddenInCurrentDirectory(); err != nil {
+			s.ErrBuf = err.Error()
+		}
 	case "?":
 		s.HelpToggle = !s.HelpToggle
 	case "enter":

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -26,6 +26,9 @@ func (n *Node) SelectLast() {
 		n.selectedChildIdx = len(n.Children) - 1
 	}
 }
+func (n *Node) ShowsHidden() bool {
+	return n.showHidden
+}
 func (n *Node) SelectFirst() {
 	n.selectedChildIdx = 0
 }

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -27,6 +27,10 @@ func (t *Tree) GetSelectedChild() *Node {
 	}
 	return nil
 }
+func (t *Tree) ToggleHiddenInCurrentDirectory() error {
+	t.CurrentDir.showHidden = !t.CurrentDir.showHidden
+	return t.CurrentDir.readChildren(defaultNodeSorting)
+}
 func (t *Tree) RefreshNodeParentByPath(path string) error {
 	// I'm assuming, that all paths are relative to my tree root
 	parentDir := filepath.Dir(path)
@@ -208,12 +212,7 @@ func InitTree(dir string, sortingFunc NodeSortingFunc) (*Tree, <-chan NodeChange
 		sortingFunc = defaultNodeSorting
 	}
 
-	root := &Node{
-		Path:     dir,
-		Info:     rootInfo,
-		Parent:   nil,
-		Children: []*Node{},
-	}
+	root := NewNode(dir, rootInfo, nil)
 
 	err = root.readChildren(sortingFunc)
 	if err != nil {

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -266,6 +266,10 @@ func (r *Renderer) renderTreeFull(tree *t.Tree, width int) ([]string, int) {
 
 		repr := indent + name
 
+		if !node.ShowsHidden() && node.Info.IsDir() {
+			repr += "◦"
+		}
+
 		if tree.GetSelectedChild() == node {
 			repr += r.Style.TreeSelectionArrow.Render(arrow)
 			currentLine = linen

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -142,6 +142,7 @@ func (r *Renderer) renderHelp(width int) (string, int) {
 		"e              Edit selected file in $EDITOR",
 		"gg             Go to top most child in current directory",
 		"G              Go to last child in current directory",
+		"H              Toggle hidden files in current directory",
 		"enter          Collapse / expand selected directory",
 		"esc            Clear error message / stop current operation",
 		"q / ctrl+c     Exit",


### PR DESCRIPTION
Allows to toggle view of hidden files or directories in current directory. Addressing #8.

I was thinking about applying the toggle to the whole tree, but it leads to questions like: "What should the tree look like, when toggling hidden off, when being in a hidden directory? Or in a subdirectory, that's not hidden itself, but who's parent is hidden?" ... etc.

I feel like toggling hidden only for current directory is fine, because you only really want to toggle, when there's a lot of hidden stuff in a current directory, that you don't really care about and it gets in your way (e.g. `~` sometimes). 

As a bonus feature of such an approach - you can toggle off hidden files in some directories, but keep them in others. This might be handy... or confuse you... depends