### PR TITLE
Added creation of install directory, if it's missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,5 @@ run:
 	go run ./cmd/bt/main.go
 
 install: build
+	mkdir -p ~/.local/bin
 	cp ./bin/bt ~/.local/bin/bt


### PR DESCRIPTION
Updated Makefile to create `~/.local/bin` directory, if it's missing.
The same was missing on **Debian 12 Bookworm**