### PR TITLE
fix: update file opening command for cross-platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,33 +34,33 @@ Flags:
 
 Key bindings:
 
-| key             | desc                                                      |
-|-----------------|-----------------------------------------------------------|
-| j / arr down    | Select next child                                         |
-| k / arr up      | Select previous child                                     |
-| h / arr left    | Move up a dir                                             |
-| l / arr right   | Enter selected directory                                  |
-| tab             | Mark selected child and move down                         |
-| shift+tab       | Mark selected child and move up                           |
-| d               | Move marked children (then 'p' to paste)                  |
-| y               | Copy marked children (then 'p' to paste)                  |
-| D               | Delete marked child                                       |
-| if / id         | Create file (if) / directory (id) in current directory    |
-| r               | Rename selected child                                     |
-| e               | Edit selected file in $EDITOR                             |
-| gg              | Go to top most child in current directory                 |
-| G               | Go to last child in current directory                     |
-| H               | Toggle hidden files in current directory                  |
-| enter           | Open / close selected directory or open file (xdg-open)   |
-| esc             | Clear error message / stop current operation / drop marks |
-| ?               | Toggle help                                               |
-| q / ctrl+c      | Exit                                                      |
+| key           | desc                                                           |
+| ------------- | -------------------------------------------------------------- |
+| j / arr down  | Select next child                                              |
+| k / arr up    | Select previous child                                          |
+| h / arr left  | Move up a dir                                                  |
+| l / arr right | Enter selected directory                                       |
+| tab           | Mark selected child and move down                              |
+| shift+tab     | Mark selected child and move up                                |
+| d             | Move marked children (then 'p' to paste)                       |
+| y             | Copy marked children (then 'p' to paste)                       |
+| D             | Delete marked child                                            |
+| if / id       | Create file (if) / directory (id) in current directory         |
+| r             | Rename selected child                                          |
+| e             | Edit selected file in $EDITOR                                  |
+| gg            | Go to top most child in current directory                      |
+| G             | Go to last child in current directory                          |
+| H             | Toggle hidden files in current directory                       |
+| enter         | Open / close selected directory or open file (xdg-open / open) |
+| esc           | Clear error message / stop current operation / drop marks      |
+| ?             | Toggle help                                                    |
+| q / ctrl+c    | Exit                                                           |
 
 ## Motivation
 
 I find myself disliking a majority of column-based terminal file managers.
-The reason for that is - when I need to copy/move some files across nested subdirectories, 
-I constantly lose context of where I am currently, because columns always go left and right. 
+The reason for that is - when I need to copy/move some files across nested subdirectories,
+I constantly lose context of where I am currently, because columns always go left and right.
 Even though those file managers are really mature and loaded with features (e.g. [ranger](https://github.com/ranger/ranger), [lf](https://github.com/gokcehan/lf), [xplr](https://github.com/sayanarijit/xplr), [nnn](https://github.com/jarun/nnn)), it's uneasy for me to perform simple tasks.
 
 I like how [broot](https://github.com/Canop/broot) renders the ui, but I guess that it's mainly usable for exploring a file tree, but not manipulating it (at least I found it this way, when I had to type a target directory for `move`).
@@ -68,6 +68,7 @@ I like how [broot](https://github.com/Canop/broot) renders the ui, but I guess t
 That's why I'm writing my own simple tool for simple use cases. It's currently lacking a bunch of features (see todo list below), but the fundamentals are here.
 
 ## TODO
+
 ```
 Functional:
 - [x] Tree rendering

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,10 +1,12 @@
 package state
 
 import (
-	t "github.com/LeperGnome/bt/internal/tree"
-	tea "github.com/charmbracelet/bubbletea"
 	"os"
 	"os/exec"
+	runtime "runtime"
+
+	t "github.com/LeperGnome/bt/internal/tree"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type Operation int
@@ -316,7 +318,13 @@ func openEditor(path string) tea.Cmd {
 }
 
 func xdgOpenFile(path string) tea.Cmd {
-	c := exec.Command("xdg-open", path)
+	var cmd string
+	if runtime.GOOS == "darwin" {
+		cmd = "open"
+	} else {
+		cmd = "xdg-open"
+	}
+	c := exec.Command(cmd, path)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return nil
 	})

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -193,7 +193,7 @@ func (r *Renderer) renderHelp(width int) (string, int) {
 		"gg               Go to top most child in current directory",
 		"G                Go to last child in current directory",
 		"H                Toggle hidden files in current directory",
-		"enter            Open / close selected directory or open file (xdg-open)",
+		"enter            Open / close selected directory or open file (xdg-open / open)",
 		"esc              Clear error message / stop current operation / drop marks",
 		"?                Toggle help",
 		"q / ctrl+c       Exit",


### PR DESCRIPTION
Implemented macOS-specific support for opening files by replacing xdg-open with the native open command. This ensures files are opened correctly on macOS systems, as xdg-open is Linux-specific and not available by default on macOS.