### PR TITLE
Feat: Implement flat navigation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ padding: 5
 file_preview: true
 highlight_indent: true
 in_place_render: false
-
+flat_navigation: false  # Ignore file hierarchy when moving up/down
 ```
 
 ## Motivation

--- a/cmd/bt/main.go
+++ b/cmd/bt/main.go
@@ -53,8 +53,9 @@ func newModel(
 	padding int,
 	filePreview bool,
 	highlightCurrentIndent bool,
+	flatNavigation bool,
 ) (model, error) {
-	s, err := state.InitState(root)
+	s, err := state.InitState(root, flatNavigation)
 	if err != nil {
 		return model{}, err
 	}
@@ -82,6 +83,7 @@ func main() {
 	flag.BoolP("in_place_render", "i", false, "In-place render (without alternate screen)")
 	flag.Bool("file_preview", true, "Enable file previews")
 	flag.Bool("highlight_indent", true, "Highlight current indent")
+	flag.Bool("flat_navigation", false, "Ignore folder structure when moving up/down")
 
 	flag.Parse()
 
@@ -98,6 +100,7 @@ func main() {
 		conf.Padding,
 		conf.FilePreview,
 		conf.HighlightIndent,
+		conf.FlatNavigation,
 	)
 	if err != nil {
 		fmt.Printf("Error on init: %v", err)

--- a/cmd/bt/main_test.go
+++ b/cmd/bt/main_test.go
@@ -29,7 +29,7 @@ func (s *BtTestSuite) SetupTest() {
 	_, err = f.WriteString("some text")
 	s.Require().NoError(err)
 
-	m, err := newModel(dir, ui.DefaultStylesheet, 5, true, true)
+	m, err := newModel(dir, ui.DefaultStylesheet, 5, true, true, true)
 	s.Require().NoError(err)
 
 	tm := teatest.NewTestModel(s.T(), m, teatest.WithInitialTermSize(100, 100))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ type BtConfig struct {
 	FilePreview     bool `mapstructure:"file_preview"`
 	HighlightIndent bool `mapstructure:"highlight_indent"`
 	InPlaceRender   bool `mapstructure:"in_place_render"`
+	FlatNavigation  bool `mapstructure:"flat_navigation"`
 }
 
 func GetConfig(flags *pflag.FlagSet) BtConfig {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -55,8 +55,8 @@ type State struct {
 	HelpToggle  bool
 }
 
-func InitState(root string) (*State, error) {
-	tree, ncc, err := t.InitTree(root, nil)
+func InitState(root string, flatNavigation bool) (*State, error) {
+	tree, ncc, err := t.InitTree(root, nil, flatNavigation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-type NodeSortingFunc func(a, b *Node) int
+type NodeSortingFunc func(a, b os.DirEntry) int
 
 type Node struct {
 	Path     string
@@ -44,6 +44,8 @@ func (n *Node) readChildren(sortFunc NodeSortingFunc) error {
 	}
 	chNodes := []*Node{}
 
+
+	slices.SortFunc(children, sortFunc)
 	for _, ch := range children {
 		chInfo, err := ch.Info()
 		if err != nil {
@@ -73,7 +75,6 @@ func (n *Node) readChildren(sortFunc NodeSortingFunc) error {
 		}
 		chNodes = append(chNodes, childToAdd)
 	}
-	slices.SortFunc(chNodes, sortFunc)
 	n.Children = chNodes
 
 	// updateing selected child index if it's out of bounds after update
@@ -110,14 +111,14 @@ func NewNode(path string, info fs.FileInfo, parent *Node) *Node {
 	}
 }
 
-func defaultNodeSorting(a, b *Node) int {
+func defaultNodeSorting(a, b os.DirEntry) int {
 	// dirs first
-	if a.Info.IsDir() != b.Info.IsDir() {
-		if a.Info.IsDir() {
+	if a.IsDir() != b.IsDir() {
+		if a.IsDir() {
 			return -1
 		} else {
 			return 1
 		}
 	}
-	return strings.Compare(strings.ToLower(a.Info.Name()), strings.ToLower(b.Info.Name()))
+	return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
 }

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -17,8 +17,9 @@ type Tree struct {
 	CurrentDir *Node
 	Marked     []*Node
 
-	sortingFunc NodeSortingFunc
-	watcher     *fsnotify.Watcher
+	sortingFunc    NodeSortingFunc
+	watcher        *fsnotify.Watcher
+	flatNavigation bool
 }
 
 func (t *Tree) GetSelectedChild() *Node {
@@ -86,14 +87,61 @@ func (t *Tree) CreateFileInCurrent(name string) error {
 func (t *Tree) CreateDirectoryInCurrent(name string) error {
 	return os.Mkdir(filepath.Join(t.CurrentDir.Path, name), os.ModePerm)
 }
-func (t *Tree) SelectNextChild() {
-	if t.CurrentDir.selectedChildIdx < len(t.CurrentDir.Children)-1 {
-		t.CurrentDir.selectedChildIdx += 1
+func RecurseIntoNode(n *Node, index int, c *Node) (*Node, int) {
+	lenChildren := len(c.Children)
+	if lenChildren == 0 {
+		return n, index
+	} else {
+		index := lenChildren - 1
+		return RecurseIntoNode(c, index, c.Children[index])
+	}
+}
+func RecurseOutOfNode(n *Node) *Node {
+	if n == nil {
+		return nil
+	}
+	if n.selectedChildIdx < len(n.Children)-1 {
+		return n
+	} else {
+		return RecurseOutOfNode(n.Parent)
 	}
 }
 func (t *Tree) SelectPreviousChild() {
-	if t.CurrentDir.selectedChildIdx > 0 {
-		t.CurrentDir.selectedChildIdx -= 1
+	if t.flatNavigation {
+		if t.CurrentDir.selectedChildIdx > 0 {
+			t.CurrentDir.selectedChildIdx -= 1
+			index := t.CurrentDir.selectedChildIdx
+			node := t.CurrentDir.Children[index]
+			dir, idx := RecurseIntoNode(t.CurrentDir, index, node)
+			t.CurrentDir = dir
+			t.CurrentDir.selectedChildIdx = idx
+		} else if t.CurrentDir.Parent != nil {
+			t.CurrentDir = t.CurrentDir.Parent
+		}
+	} else {
+		if t.CurrentDir.selectedChildIdx > 0 {
+			t.CurrentDir.selectedChildIdx -= 1
+		}
+	}
+}
+func (t *Tree) SelectNextChild() {
+	if t.flatNavigation {
+		selected := t.GetSelectedChild()
+		if selected != nil && len(selected.Children) > 0 {
+			t.CurrentDir = selected
+		} else if t.CurrentDir.selectedChildIdx < len(t.CurrentDir.Children)-1 {
+			t.CurrentDir.selectedChildIdx += 1
+		} else {
+			dir := RecurseOutOfNode(t.CurrentDir.Parent)
+			if dir != nil {
+				t.CurrentDir = dir
+				t.CurrentDir.selectedChildIdx += 1
+			}
+		}
+	} else {
+		if t.CurrentDir.selectedChildIdx < len(t.CurrentDir.Children)-1 {
+			t.CurrentDir.selectedChildIdx += 1
+		}
 	}
 }
 func (t *Tree) SetSelectedChildAsCurrent() error {
@@ -221,7 +269,7 @@ func (t *Tree) CollapseOrExpandSelected() error {
 	return nil
 }
 
-func InitTree(dir string, sortingFunc NodeSortingFunc) (*Tree, <-chan NodeChange, error) {
+func InitTree(dir string, sortingFunc NodeSortingFunc, flatNavigation bool) (*Tree, <-chan NodeChange, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, nil, err
@@ -259,10 +307,11 @@ func InitTree(dir string, sortingFunc NodeSortingFunc) (*Tree, <-chan NodeChange
 	}
 
 	tree := &Tree{
-		Root:        root,
-		CurrentDir:  root,
-		sortingFunc: sortingFunc,
-		watcher:     watcher,
+		Root:           root,
+		CurrentDir:     root,
+		sortingFunc:    sortingFunc,
+		watcher:        watcher,
+		flatNavigation: flatNavigation,
 	}
 	return tree, changeChan, nil
 }

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -52,7 +52,7 @@ func (s *TreeTestSuite) SetupTest() {
 	)
 
 	// Init Tree with this dir
-	tree, _, err := InitTree(rootPath, defaultNodeSorting)
+	tree, _, err := InitTree(rootPath, defaultNodeSorting, true)
 	s.Require().NoError(err)
 	s.tree = tree
 }


### PR DESCRIPTION
I think you've done really well here with this tool, I just needed to make this change so I didn't have to keep fighting my muscle memory from using other tools.

I did try a few other options before landing on this approach to implementing 'flat navigation' semantics:

1. Use the rendering function to assign up/down nodes attached to the `Tree` based on lines above/below current selection
    ❌  Coupled the UI to the `Tree` representation (although the logic was easy to understand)
2. Create a linked list of `Node`s within the `Tree`
    ❌  Healing that data structure upon `Tree` changes seemed like a high maintenance burden
3. Determine the up/down node on the fly
    ✅  Only required code changes to the `Next`|`Previous` functions
    
PS I did update the signature of the default sorting function to accept `* os.DirEntry`. In my initial attempts this tripped me up as I expected the 'entries' to be sorted before the tree was constructed (also means that in the future the index of those range loops will have a real meaning).

Hope you find this useful 👍 